### PR TITLE
Opening up dependencies so it works with Rails 5

### DIFF
--- a/rack-policy.gemspec
+++ b/rack-policy.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rack', '~> 1.1'
+  spec.add_dependency 'rack'
 
-  spec.add_development_dependency 'bundler', '>= 1.5.0', '< 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake', '>= 10.0'
+  spec.add_development_dependency 'rspec', '>= 3.0'
 end


### PR DESCRIPTION
The dependencies on the gem were too restrictive. By changing them the gem is 100% working fine with Rails 5.1.5